### PR TITLE
Feature/Product list

### DIFF
--- a/src/main/java/com/Techeer/Team_C/domain/product/controller/CrawlerController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/controller/CrawlerController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(API_PREFIX + "/crawler")
 @RequiredArgsConstructor
-public class CrawlierController {
+public class CrawlerController {
 
     private final ProductCrawler productCrawler;
     private final ProductRegisterMapper mapper;

--- a/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
@@ -60,18 +60,6 @@ public class ProductController {
         //size : 한 번에 나타날 최대 개수
         //sort : 분류 기준
         return ResponseEntity.ok(productService.pageList(keyword, page));
-
-        for (int i = 0; i < resultList.size(); i++) {  //한 페이지에 보여줄 결과를 Json 리스트에 넣음
-            JSONObject data = new JSONObject(resultList.get(i).toJson());
-            jarray.add(data);
-        }
-
-        JSONObject obj = new JSONObject();
-        obj.put("success", true);
-        obj.put("status", 200);
-        obj.put("data", jarray);
-        obj.put("totalCount", totalCount);
-        return obj.toString();
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -26,6 +27,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.Techeer.Team_C.global.utils.Constants.API_PREFIX;
 
@@ -57,27 +61,33 @@ public class ProductController {
         //sort : 분류 기준
         return ResponseEntity.ok(productService.pageList(keyword, page));
 
+
+        for (int i = 0; i < resultList.size(); i++) {  //한 페이지에 보여줄 결과를 Json 리스트에 넣음
+            JSONObject data = new JSONObject(resultList.get(i).toJson());
+            jarray.add(data);
+        }
+
+        JSONObject obj = new JSONObject();
+        obj.put("success", true);
+        obj.put("status", 200);
+        obj.put("data", jarray);
+        obj.put("totalCount",totalCount);
+        return obj.toString();
     }
 
-//    @GetMapping("/list/{id}")
-//    @ApiOperation(value = "사용자 등록 상품 목록 조회", notes = "상품 등록 API")
-//    public ResponseEntity<List<ProductRegisterResponseDto>> getList(@RequestBody @PathVariable("id") Long userId) {
-//
-//        return ResponseEntity
-//                .ok(productService.registerList(userId).stream().map(mapper::toResponseDto).collect(Collectors.toList()));
-//    }
+    @GetMapping("/list")
+    @ApiOperation(value = "사용자 등록 상품 목록 조회", notes = "상품 등록 API, 헤더에 토큰 정보")
+    public ResponseEntity<List<ProductRegisterResponseDto>> getList() {
+        return ResponseEntity.ok(productService.registerList().stream().map(mapper::toResponseDto).collect(Collectors.toList()));
+    }
 
     @PostMapping("/register/{id}")
     @ApiOperation(value = "상품 알림 등록", notes = "상품 알림 등록 API, 헤더에 토큰 정보 필요")
-    public ResponseEntity<ProductRegisterResponseDto> save(
-            @RequestBody @Valid final ProductRegisterRequestDto productRegisterRequestDto,
-            @PathVariable("id") Long productId) {
-
-        return ResponseEntity.ok(mapper.toResponseDto(
-                productService.saveRegister(productRegisterRequestDto, productId)));
+    public ResponseEntity<ProductRegisterResponseDto> save(@RequestBody @Valid final ProductRegisterRequestDto productRegisterRequestDto, @PathVariable("id") Long productId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toResponseDto(productService.saveRegister(productRegisterRequestDto, productId)));
     }
 
-    @PutMapping("/register/{id}")
+    @PatchMapping("/register/{id}")
     @ApiOperation(value = "상품 알림 등록 정보 수정", notes = "상품 알림 등록 정보 수정 API, 헤더에 토큰 정보 필요")
     public ResponseEntity<ProductRegisterResponseDto> editRegister(
             @RequestBody @Valid final ProductRegisterEditDto productEditDto,

--- a/src/main/java/com/Techeer/Team_C/domain/product/entity/ProductRegister.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/entity/ProductRegister.java
@@ -50,18 +50,16 @@ public class ProductRegister extends BaseTimeEntity {
     private boolean status;
 
     @Builder
-    public ProductRegister(User user, Product product, Integer desiredPrice, boolean status) {
+    public ProductRegister(User user, Product product, int desiredPrice, boolean status) {
         this.user = user;
         this.product = product;
         this.desiredPrice = desiredPrice;
         this.status = status;
     }
 
-    public void update(User user, Product product, int desiredPrice) {
+    public void update(int desiredPrice, boolean status) {
         this.desiredPrice = desiredPrice;
-        this.user = user;
-        this.product = product;
-        this.status = true;
+        this.status = status;
     }
 
 }

--- a/src/main/java/com/Techeer/Team_C/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/Techeer/Team_C/global/config/WebSecurityConfig.java
@@ -64,10 +64,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests() // 요청에 대한 사용권한 체크
                 //.antMatchers("/admin/**").hasRole("ADMIN")
-                .antMatchers("/api/v1/users/", "/api/v1/auth/", "/api/v1/products/register/*")
+                .antMatchers("/api/v1/users/", "/api/v1/auth/", "/api/v1/products/register/*", "/api/v1/user/login")
                 .hasRole("USER")
-                .antMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**",
-                        "/api/v1/user/login").permitAll()
+                .antMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**").permitAll()
                 .anyRequest().permitAll()// 그외 나머지 요청은 누구나 접근 가능
                 .and()
                 .exceptionHandling()
@@ -87,3 +86,4 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         // JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 전에 넣는다
     }
 }
+

--- a/src/main/java/com/Techeer/Team_C/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/Techeer/Team_C/global/error/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
 
     //ProductResister
     PRODUCTREGISTER_NOT_FOUND(400, "I002", "Product not registered"),
-    DUPLICATE_PRODUCTREGISTER(400, "I003", "Already exist productRegister" )
+    DUPLICATE_PRODUCTREGISTER(400, "I003", "Product already registered" )
     ;
     private final String code;
     private final String message;

--- a/src/test/java/com/Techeer/Team_C/domain/product/service/ProductCrawlerTest.java
+++ b/src/test/java/com/Techeer/Team_C/domain/product/service/ProductCrawlerTest.java
@@ -10,7 +10,7 @@ class ProductCrawlerTest {
     ProductCrawler crawler = new ProductCrawler();
 
     @Test
-    public void getProductPage() thprices IOException{
+    public void getProductPage() throws IOException{
         //given
         String url = "http://search.danawa.com/dsearch.php?query=%EB%A7%A5%EB%B6%81+%ED%94%84%EB%A1%9C+14";
 


### PR DESCRIPTION
## 변경사항
#25 
### 사용자 등록 물품 리스트 조회 API 생성
`GET /api/v1/products/list`
- 조회 시 사용자 등록 물품 리스트 조회
- 요청 시 헤더에 Bearer 토큰 정보와 함께 전송해주세요.

### 알림 등록 삭제했던 물품을 다시 등록하는 로직 추가
- DELETE 메서드를 통해 알림 기능을 삭제했던 물품을 다시 등록할 수 있도록 했습니다.
- DB에 존재하는 물품이지만 status=false 인 경우 status=true 로 변경

### 사용자 알림 등록 정보 API 변경
변경 전 : `PUT /api/v1/products/register/{id}`
변경 후 : `PATCH /api/v1/products/register/{id}`

- 가격 정보만 변경하기 때문에 PATCH 메서드가 더 적합하다고 판단해 변경했습니다.

### Response 형태 수정
- 기존에 success, statusCode를 함께 전달하던 것에서 data만 반환하는 형식으로 변경하였습니다.

### Crawler Controller 오타 수정
- 변경 전 : `CrawlierController`
- 변경 후 : `CrawlerController`

<br>

## TODO
- 크롤링 후 Product 생성하는 로직