### PR TITLE
Feature/check product

### DIFF
--- a/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
@@ -66,13 +66,19 @@ public class ProductController {
     @GetMapping("/list")
     @ApiOperation(value = "사용자 등록 상품 목록 조회", notes = "상품 등록 API, 헤더에 토큰 정보")
     public ResponseEntity<List<ProductRegisterResponseDto>> getList() {
-        return ResponseEntity.ok(productService.registerList().stream().map(mapper::toResponseDto).collect(Collectors.toList()));
+        return ResponseEntity.ok(productService.registerList()
+                .stream()
+                .map(mapper::toResponseDto)
+                .collect(Collectors.toList()));
     }
 
-    @PostMapping("/register/{id}")
+    @PostMapping("/register")
     @ApiOperation(value = "상품 알림 등록", notes = "상품 알림 등록 API, 헤더에 토큰 정보 필요")
-    public ResponseEntity<ProductRegisterResponseDto> save(@RequestBody @Valid final ProductRegisterRequestDto productRegisterRequestDto, @PathVariable("id") Long productId) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toResponseDto(productService.saveRegister(productRegisterRequestDto, productId)));
+    public ResponseEntity<ProductRegisterResponseDto> save(
+            @RequestBody @Valid final ProductRegisterRequestDto productRegisterRequestDto,
+            @RequestParam(value = "product") String productName) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(mapper.toResponseDto(productService.saveRegister(productRegisterRequestDto, productName)));
     }
 
     @PatchMapping("/register/{id}")
@@ -89,7 +95,8 @@ public class ProductController {
     @DeleteMapping("/register/{id}")
     public ResponseEntity<Void> deleteResister(@PathVariable("id") Long productId) {
         productService.deleteRegister(productId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .build();
     }
 
     @ApiOperation(value = "상품의 몰 정보", notes = "crawling 시 최저가 업데이트 여부 확인을 위함")

--- a/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductRegisterMapper.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductRegisterMapper.java
@@ -14,6 +14,7 @@ public class ProductRegisterMapper {
               .userId(entity.getUser().getUserId())
               .productId(entity.getProduct().getProductId())
               .desiredPrice(entity.getDesiredPrice())
+              .minimumPrice(entity.getMinimumPrice())
               .build();
    }
 }

--- a/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductRegisterRequestDto.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductRegisterRequestDto.java
@@ -11,4 +11,5 @@ public class ProductRegisterRequestDto {
 
     @NotNull
     private int desiredPrice;
+    private String url;
 }

--- a/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductRegisterResponseDto.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductRegisterResponseDto.java
@@ -17,4 +17,6 @@ public class ProductRegisterResponseDto {
     private Long productId;
 
     private int desiredPrice;
+
+    private int minimumPrice;
 }

--- a/src/main/java/com/Techeer/Team_C/domain/product/entity/ProductRegister.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/entity/ProductRegister.java
@@ -37,6 +37,8 @@ public class ProductRegister extends BaseTimeEntity {
 
     private int desiredPrice;
 
+    private int minimumPrice;
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
@@ -50,10 +52,11 @@ public class ProductRegister extends BaseTimeEntity {
     private boolean status;
 
     @Builder
-    public ProductRegister(User user, Product product, int desiredPrice, boolean status) {
+    public ProductRegister(User user, Product product, int desiredPrice, int minimumPrice, boolean status) {
         this.user = user;
         this.product = product;
         this.desiredPrice = desiredPrice;
+        this.minimumPrice = minimumPrice;
         this.status = status;
     }
 

--- a/src/main/java/com/Techeer/Team_C/domain/product/repository/ProductRegisterMysqlRepository.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/repository/ProductRegisterMysqlRepository.java
@@ -11,13 +11,19 @@ import java.util.Optional;
 
 public interface ProductRegisterMysqlRepository extends JpaRepository<ProductRegister, Long> {
 
-    List<ProductRegister> findAllByUser(User user);
+    List<ProductRegister> findAllByUserAndStatus(User user, boolean status);
 
     Optional<ProductRegister> findByUserAndProduct(User user, Product product);
 
     @Transactional
-    default ProductRegister build(User user, Product product, int desiredPrice, boolean status) {
-        ProductRegister productRegister = ProductRegister.builder().user(user).product(product).desiredPrice(desiredPrice).status(status).build();
+    default ProductRegister build(User user, Product product, int desiredPrice, int minimumPrice, boolean status) {
+        ProductRegister productRegister = ProductRegister.builder()
+                .user(user)
+                .product(product)
+                .desiredPrice(desiredPrice)
+                .minimumPrice(minimumPrice)
+                .status(status)
+                .build();
 
         return productRegister;
     }

--- a/src/main/java/com/Techeer/Team_C/domain/product/service/ProductCrawler.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/service/ProductCrawler.java
@@ -236,7 +236,7 @@ public class ProductCrawler {
     }
 
     @Transactional
-    public void storeProduct(ProductCrawlingDto productCrawlingDto) {
+    public Optional<Product> storeProduct(ProductCrawlingDto productCrawlingDto) {
         List<Mall> mallList = new LinkedList<>();
         Optional<Product> registeredProduct = productMysqlRepository.findByName(
             productCrawlingDto.getTitle());
@@ -263,7 +263,7 @@ public class ProductCrawler {
             }
             product.setMallInfo(mallList);
 
-            productMysqlRepository.save(product);
+            return Optional.of(productMysqlRepository.save(product));
         }
     }
 

--- a/src/main/java/com/Techeer/Team_C/domain/product/service/ProductService.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/service/ProductService.java
@@ -35,6 +35,7 @@ public class ProductService {
 
     private final ProductMysqlRepository productMysqlRepository;
     private final ProductRegisterMysqlRepository productRegisterMysqlRepository;
+    private final ProductCrawler productCrawler;
     private final ModelMapper modelMapper;
     private final ProductMallMysqlRepository productMallMysqlRepository;
     private final UserRepository userRepository;
@@ -43,7 +44,6 @@ public class ProductService {
         return modelMapper.map(product, ProductDto.class);
     }
 
-
     public ProductDto findProduct(Long id) {
 
         Optional<Product> product = productMysqlRepository.findById(id);
@@ -51,7 +51,8 @@ public class ProductService {
             throw new BusinessException("해당 상품 정보가 존재하지 않습니다.", PRODUCT_NOT_FOUND);
         }
 
-        return product.map(productEntity -> dtoConverter(productEntity)).get();
+        return product.map(productEntity -> dtoConverter(productEntity))
+                .get();
     }
 
     public ProductPageListResponseDto pageList(String keyword, Pageable page) {
@@ -59,7 +60,9 @@ public class ProductService {
 
         ProductPageListResponseDto result = new ProductPageListResponseDto();
 
-        result.setData(lists.getContent().stream().map(productEntity -> dtoConverter(productEntity))
+        result.setData(lists.getContent()
+                .stream()
+                .map(productEntity -> dtoConverter(productEntity))
                 .collect(Collectors.toList()));
 
         result.setTotalCount(productMysqlRepository.countByNameContaining(keyword));
@@ -73,7 +76,8 @@ public class ProductService {
     }
 
     public List<ProductRegister> registerList() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
         if (authentication == null || authentication.getName() == null) {
             throw new BusinessException("Security Context 에 인증 정보가 없습니다", EMPTY_TOKEN_DATA);
         }
@@ -89,9 +93,10 @@ public class ProductService {
 
     @Transactional
     public ProductRegister saveRegister(ProductRegisterRequestDto productRegisterRequestDto,
-            Long productId) {
+                                        String productName) {
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
         if (authentication == null || authentication.getName() == null) {
             throw new BusinessException("Security Context 에 인증 정보가 없습니다", EMPTY_TOKEN_DATA);
         }
@@ -101,24 +106,25 @@ public class ProductService {
         if (!userById.isPresent()) {
             throw new BusinessException("존재하지 않는 사용자 입니다.", USER_NOT_FOUND);
         }
-        Optional<Product> productById = productMysqlRepository.findById(productId);
-        if (!productById.isPresent()) {
-            throw new BusinessException("존재하지 않는 물품 입니다.", PRODUCT_NOT_FOUND);
+        Optional<Product> productByName = productMysqlRepository.findByName(productName);
+        if (!productByName.isPresent()) {
+            productByName = productCrawler.storeProduct(
+                    productCrawler.DanawaCrawling(productRegisterRequestDto.getUrl()));
         }
-        Optional<ProductRegister> productRegisterById = productRegisterMysqlRepository.findByUserAndProduct(userById.get(), productById.get());
+        Optional<ProductRegister> productRegisterById = productRegisterMysqlRepository.findByUserAndProduct(
+                userById.get(), productByName.get());
         if (productRegisterById.isPresent()) {
             ProductRegister entity = productRegisterById.get();
-            if(!entity.isStatus()) {
-                entity.update(productRegisterRequestDto.getDesiredPrice(),true);
+            if (!entity.isStatus()) {
+                entity.update(productRegisterRequestDto.getDesiredPrice(), true);
                 return entity;
-            }
-            else{
+            } else {
                 throw new BusinessException("이미 등록한 상품입니다.", DUPLICATE_PRODUCTREGISTER);
             }
         }
 
         ProductRegister productRegister = productRegisterMysqlRepository.build(userById.get(),
-                productById.get(), productRegisterRequestDto.getDesiredPrice(), true);
+                productByName.get(), productRegisterRequestDto.getDesiredPrice(), true);
         productRegisterMysqlRepository.save(productRegister);
 
         return productRegister;
@@ -126,8 +132,9 @@ public class ProductService {
 
     @Transactional
     public ProductRegister editRegister(ProductRegisterEditDto productRegisterEditDto,
-            Long productId) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+                                        Long productId) {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
         if (authentication == null || authentication.getName() == null) {
             throw new BusinessException("Security Context 에 인증 정보가 없습니다", EMPTY_TOKEN_DATA);
         }
@@ -138,7 +145,8 @@ public class ProductService {
             throw new BusinessException("존재하지 않는 사용자 입니다.", USER_NOT_FOUND);
         }
         Optional<ProductRegister> productRegisterById = productRegisterMysqlRepository.findByUserAndProduct(
-                userById.get(), productMysqlRepository.findById(productId).get());
+                userById.get(), productMysqlRepository.findById(productId)
+                        .get());
 
         if (!productRegisterById.isPresent()) {
             throw new BusinessException("등록하지 않은 물품 입니다.", PRODUCTREGISTER_NOT_FOUND);
@@ -153,7 +161,8 @@ public class ProductService {
 
     @Transactional
     public void deleteRegister(Long productId) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
         if (authentication == null || authentication.getName() == null) {
             throw new BusinessException("Security Context 에 인증 정보가 없습니다", EMPTY_TOKEN_DATA);
         }
@@ -173,7 +182,8 @@ public class ProductService {
         Optional<ProductRegister> productRegisterById = productRegisterMysqlRepository.findByUserAndProduct(
                 userById.get(), productById.get());
         productRegisterById.ifPresentOrElse(productRegister -> {
-            productRegisterById.get().setStatus(false);
+            productRegisterById.get()
+                    .setStatus(false);
             productRegisterMysqlRepository.save(productRegister);
         }, () -> {
             throw new BusinessException("등록하지 않은 물품입니다.", PRODUCTREGISTER_NOT_FOUND);


### PR DESCRIPTION
## 변경사항

### 사용자가 상품 알림 등록 시 product 테이블에 상품이 존재하지 않으면 상품 저장하는 로직 추가
- 기존에 요청 시 productId로 알림 등록하던 대신, 상품명으로 변경했습니다. 따라서 프론트에서 사용자 제품 등록 시 Query Parameter 형태로 상품명을 보내주셔야합니다.
- 요청 body에는 해당 제품의 다나와 페이지 url도 같이 보내주셔야합니다.
- `POST /api/v1/products/register/{id}` 에서 `POST /api/v1/products/register` 로 변경
- 자세한 내용은 노션에 정리했습니다 : https://www.notion.so/e0a4f4b9471e4e16b932d7e835909768


### `ProductCrawler` 내 `storeProduct` 함수 반환 형태 변경
- `void` -> `Optional<Product>`로 변경했습니다.

<br>

## 추가사항
- @ohhondgi 님이 구현해주신 `api/v1/crawler/product` api는 따로 필요하지 않을 것 같습니다! 그래도 혹시 모르니 삭제는 하지 않고 두는 것도 좋을 것 같아요.
- 위 api 구현 시 PUT 메서드를 사용하셨는데, 제품 알림 등록시에도 POST로 하는것이 좋을 지, PUT 메서드를 사용하는 것이 좋을 지 의논해보고 싶습니다.
- 혹시 설명이 더 필요하시면 코멘트 자유롭게 남겨주세요!