### PR TITLE
Feature/price history

### DIFF
--- a/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.Techeer.Team_C.domain.product.controller;
 
 import com.Techeer.Team_C.domain.product.dto.ProductDto;
+import com.Techeer.Team_C.domain.product.dto.ProductHistoryResponseDto;
 import com.Techeer.Team_C.domain.product.dto.ProductPageListResponseDto;
 import com.Techeer.Team_C.domain.product.dto.ProductRegisterEditDto;
 import com.Techeer.Team_C.domain.product.dto.ProductRegisterMapper;
@@ -103,6 +104,12 @@ public class ProductController {
     @GetMapping("/product/mallList/{id}")
     public ResponseEntity<List<Mall>> getMallList(@PathVariable("id") Long productId) {
         return ResponseEntity.ok(productService.getProductMallList(productId));
+    }
+
+    @ApiOperation(value = "상품의 가격 추이 그래프")
+    @GetMapping("history/{id}")
+    public ResponseEntity<ProductHistoryResponseDto> getProductHistory(@PathVariable("id") Long productId) {
+        return ResponseEntity.ok(productService.getProductHistory(productId));
     }
 
 }

--- a/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/controller/ProductController.java
@@ -1,5 +1,7 @@
 package com.Techeer.Team_C.domain.product.controller;
 
+import static com.Techeer.Team_C.global.utils.Constants.API_PREFIX;
+
 import com.Techeer.Team_C.domain.product.dto.ProductDto;
 import com.Techeer.Team_C.domain.product.dto.ProductHistoryResponseDto;
 import com.Techeer.Team_C.domain.product.dto.ProductPageListResponseDto;
@@ -11,6 +13,9 @@ import com.Techeer.Team_C.domain.product.entity.Mall;
 import com.Techeer.Team_C.domain.product.service.ProductService;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,18 +27,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static com.Techeer.Team_C.global.utils.Constants.API_PREFIX;
 
 @RestController
 @RequestMapping(API_PREFIX + "/products")
@@ -57,8 +54,8 @@ public class ProductController {
     @ApiImplicitParam(name = "keyword", value = "검색 할 내용")
 
     public ResponseEntity<ProductPageListResponseDto> showSearch(
-            @RequestBody @RequestParam("keyword") String keyword,
-            @PageableDefault(size = 9, sort = "name", direction = Sort.Direction.ASC) Pageable page) {
+        @RequestBody @RequestParam("keyword") String keyword,
+        @PageableDefault(size = 9, sort = "name", direction = Sort.Direction.ASC) Pageable page) {
         //size : 한 번에 나타날 최대 개수
         //sort : 분류 기준
         return ResponseEntity.ok(productService.pageList(keyword, page));
@@ -68,28 +65,29 @@ public class ProductController {
     @ApiOperation(value = "사용자 등록 상품 목록 조회", notes = "상품 등록 API, 헤더에 토큰 정보")
     public ResponseEntity<List<ProductRegisterResponseDto>> getList() {
         return ResponseEntity.ok(productService.registerList()
-                .stream()
-                .map(mapper::toResponseDto)
-                .collect(Collectors.toList()));
+            .stream()
+            .map(mapper::toResponseDto)
+            .collect(Collectors.toList()));
     }
 
     @PostMapping("/register")
     @ApiOperation(value = "상품 알림 등록", notes = "상품 알림 등록 API, 헤더에 토큰 정보 필요")
     public ResponseEntity<ProductRegisterResponseDto> save(
-            @RequestBody @Valid final ProductRegisterRequestDto productRegisterRequestDto,
-            @RequestParam(value = "product") String productName) {
+        @RequestBody @Valid final ProductRegisterRequestDto productRegisterRequestDto,
+        @RequestParam(value = "product") String productName) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(mapper.toResponseDto(productService.saveRegister(productRegisterRequestDto, productName)));
+            .body(mapper.toResponseDto(
+                productService.saveRegister(productRegisterRequestDto, productName)));
     }
 
     @PatchMapping("/register/{id}")
     @ApiOperation(value = "상품 알림 등록 정보 수정", notes = "상품 알림 등록 정보 수정 API, 헤더에 토큰 정보 필요")
     public ResponseEntity<ProductRegisterResponseDto> editRegister(
-            @RequestBody @Valid final ProductRegisterEditDto productEditDto,
-            @PathVariable("id") Long productId) {
+        @RequestBody @Valid final ProductRegisterEditDto productEditDto,
+        @PathVariable("id") Long productId) {
 
         return ResponseEntity.ok(
-                mapper.toResponseDto(productService.editRegister(productEditDto, productId)));
+            mapper.toResponseDto(productService.editRegister(productEditDto, productId)));
     }
 
     @ApiOperation(value = "상품 알림 등록 삭제", notes = "상품 알림 등록 삭제 API, 헤더에 토큰 정보 필요")
@@ -97,7 +95,7 @@ public class ProductController {
     public ResponseEntity<Void> deleteResister(@PathVariable("id") Long productId) {
         productService.deleteRegister(productId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .build();
+            .build();
     }
 
     @ApiOperation(value = "상품의 몰 정보", notes = "crawling 시 최저가 업데이트 여부 확인을 위함")
@@ -107,8 +105,9 @@ public class ProductController {
     }
 
     @ApiOperation(value = "상품의 가격 추이 그래프")
-    @GetMapping("history/{id}")
-    public ResponseEntity<ProductHistoryResponseDto> getProductHistory(@PathVariable("id") Long productId) {
+    @GetMapping("/price-history/{id}")
+    public ResponseEntity<ProductHistoryResponseDto> getProductHistory(
+        @PathVariable("id") Long productId) {
         return ResponseEntity.ok(productService.getProductHistory(productId));
     }
 

--- a/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductHistoryResponseDto.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductHistoryResponseDto.java
@@ -1,0 +1,26 @@
+package com.Techeer.Team_C.domain.product.dto;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ProductHistoryResponseDto {
+
+    private List<MallPriceHistoryInfo> mallHistoryInfoList;
+    private LocalDateTime date;
+
+    @Builder
+    @Getter
+    @Setter
+    public static class MallPriceHistoryInfo{
+        private String mallName;
+        private List<Integer> priceList;
+    }
+}

--- a/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductHistoryResponseDto.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/dto/ProductHistoryResponseDto.java
@@ -1,8 +1,6 @@
 package com.Techeer.Team_C.domain.product.dto;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.LinkedList;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +17,8 @@ public class ProductHistoryResponseDto {
     @Builder
     @Getter
     @Setter
-    public static class MallPriceHistoryInfo{
+    public static class MallPriceHistoryInfo {
+
         private String mallName;
         private List<Integer> priceList;
     }

--- a/src/main/java/com/Techeer/Team_C/domain/product/entity/ProductHistory.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/entity/ProductHistory.java
@@ -1,12 +1,6 @@
 package com.Techeer.Team_C.domain.product.entity;
 
 import com.Techeer.Team_C.global.utils.dto.BaseTimeEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
@@ -14,6 +8,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter

--- a/src/main/java/com/Techeer/Team_C/domain/product/repository/ProductHistoryMysqlRepository.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/repository/ProductHistoryMysqlRepository.java
@@ -3,10 +3,16 @@ package com.Techeer.Team_C.domain.product.repository;
 import com.Techeer.Team_C.domain.product.entity.Product;
 import com.Techeer.Team_C.domain.product.entity.ProductHistory;
 import java.util.List;
+import java.util.Stack;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface ProductHistoryMysqlRepository extends JpaRepository<ProductHistory, Long> {
 
     List<ProductHistory> findTop3ByProduct(Product product);
+
+    @Query(value = "SELECT * FROM product_history where product_id = :id order by created_date desc LIMIT 30"
+    ,nativeQuery = true)
+    Stack<ProductHistory> findTop30ByProductAndOrderByCreatedDateDesc(Long id);
 }

--- a/src/main/java/com/Techeer/Team_C/domain/product/repository/ProductHistoryMysqlRepository.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/repository/ProductHistoryMysqlRepository.java
@@ -13,6 +13,6 @@ public interface ProductHistoryMysqlRepository extends JpaRepository<ProductHist
     List<ProductHistory> findTop3ByProduct(Product product);
 
     @Query(value = "SELECT * FROM product_history where product_id = :id order by created_date desc LIMIT 30"
-    ,nativeQuery = true)
+        , nativeQuery = true)
     Stack<ProductHistory> findTop30ByProductAndOrderByCreatedDateDesc(Long id);
 }

--- a/src/main/java/com/Techeer/Team_C/domain/product/service/ProductCrawler.java
+++ b/src/main/java/com/Techeer/Team_C/domain/product/service/ProductCrawler.java
@@ -217,8 +217,8 @@ public class ProductCrawler {
             product.setMallInfo(mallList);
 
             // pricehistory에 상위 3개의 mall 정보 저장
-            for (int i =0; i<mallDtoList.size(); i++){
-                if (i < 3){
+            for (int i = 0; i < mallDtoList.size(); i++) {
+                if (i < 3) {
                     MallDto malldto = mallDtoList.get(i);
                     productHistoryMysqlRepository.save(
                         ProductHistory.builder()

--- a/src/main/java/com/Techeer/Team_C/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/Techeer/Team_C/global/error/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
     PRODUCT_NOT_FOUND(400,"I001","Not found product"),
     Mall_NOT_FOUND(400,"I002", "Not found Mall"),
 
+    //Price history
+    UNEXPECTED_MALL(400, "H001", "Unexpected mall information in price history table"),
+
     //ProductResister
     PRODUCTREGISTER_NOT_FOUND(400, "I003", "Product not registered"),
     DUPLICATE_PRODUCTREGISTER(400, "I004", "Product already registered" )


### PR DESCRIPTION
특정 product에 대한 priceHistory 정보를 가져와 가격 추이 그래프의 data에 맞게 변동해주는 API입니다.

**Swagger Test**
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/33611439/178861206-50a29743-ddf7-4d50-9fb8-3e997b18d7e7.png">

먼저, 특정 상품에 대해 crawling하여 가져온 productcrawlingDto를 db에 저장합니다.


<img width="1047" alt="image" src="https://user-images.githubusercontent.com/33611439/178861450-6ff4986f-509d-4688-a053-8da94699f7d7.png">

먼저, 기존과 동일하게 product에 대한 mall 정보가 db에 저장되는 것을 보실 수 있으며,


<img width="1005" alt="image" src="https://user-images.githubusercontent.com/33611439/178861379-954f0c7a-2a14-4a3a-a980-3b6c3e386795.png">

이전과 다르게, 저장했던 시점의 상위 3개의 mall정보를 priceHistory table에 저장되는 logic을 추가하였습니다.


<img width="1035" alt="image" src="https://user-images.githubusercontent.com/33611439/178862145-46b45b01-d8e3-4d1c-a09f-f506fa88f8a1.png">

그리고, 주기적인 crawling method를 통해 priceHistory에 data가 쌓인 것을 가격 추이 그래프의 data format에 맞게 가져오는 api를 호출합니다. ( 가격의 변동을 확인하기 편하도록 임의로 수정하였습니다.)


<img width="1398" alt="image" src="https://user-images.githubusercontent.com/33611439/178862178-78b4ba64-dfd4-4331-9d8c-6ab9d177e583.png">

특정 product id를 입력하면,

<img width="224" alt="image" src="https://user-images.githubusercontent.com/33611439/178862435-fd931b47-43ed-4f38-90a2-615b297a9dcf.png">
<img width="288" alt="image" src="https://user-images.githubusercontent.com/33611439/178862550-bae503fa-491c-473a-b07d-bbbf2cffe73f.png">

priceHistory에서 data를 가져와 가격 추이 그래프 data 형식에 맞게 변환되는 것을 보실 수 있습니다.

아직 product history에서 data를 가져올 때, 최근 데이터 순으로 가져오는 query에 대한 최적화는 생각중에 있습니다...
일단은 created_at 을 내림차순으로 하여 가져오는 식으로만 구현되어있는 상태입니다.
추후에 좋은 의견이 있다면 언제든지 알려주시면 반영하겠습니다 :)


