### PR TITLE
Feature/social login refactor

### DIFF
--- a/src/main/java/com/Techeer/Team_C/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.Techeer.Team_C.domain.auth.controller;
 
+import com.Techeer.Team_C.domain.auth.entity.AuthorizationKakao;
 import com.Techeer.Team_C.domain.user.dto.LoginFormDto;
 import com.Techeer.Team_C.domain.auth.dto.TokenDto;
 import com.Techeer.Team_C.domain.auth.dto.TokenRefreshDto;
@@ -7,9 +8,9 @@ import com.Techeer.Team_C.domain.auth.service.AuthService;
 
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.json.simple.JSONObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,15 +56,17 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @GetMapping("/kakao")
+    @GetMapping("/token/kakao")
     @ApiOperation(value = "kakao 소셜 로그인", notes = "소셜로그인 API (kakao)")
-    public void kakaoCallback(@RequestParam String code) {
-        System.out.println(code);
+    public ResponseEntity<TokenDto> kakaoCallback(@RequestParam("code") String code) {
+
+        return ResponseEntity.ok(authService.oauth2AuthorizationKakao(code));
     }
 
-    @GetMapping("/google")
+    @GetMapping("/token/google")
     @ApiOperation(value = "google 소셜 로그인", notes = "소설로그인 API (google)")
-    public void googleCallback(@RequestParam String code) {
-        System.out.println(code);
+    public ResponseEntity<TokenDto> googleCallback(@RequestParam("code") String code) {
+
+        return ResponseEntity.ok(authService.oauth2AuthorizationGoogle(code));
     }
 }

--- a/src/main/java/com/Techeer/Team_C/domain/auth/dto/SessionUser.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/dto/SessionUser.java
@@ -2,6 +2,7 @@ package com.Techeer.Team_C.domain.auth.dto;
 
 import com.Techeer.Team_C.domain.user.entity.User;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 

--- a/src/main/java/com/Techeer/Team_C/domain/auth/entity/AuthorizationGoogle.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/entity/AuthorizationGoogle.java
@@ -1,0 +1,16 @@
+package com.Techeer.Team_C.domain.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorizationGoogle {
+    private String access_token;
+    private String expires_in;
+    private String id_token;
+    private String scope;
+    private String token_type;
+}

--- a/src/main/java/com/Techeer/Team_C/domain/auth/entity/AuthorizationKakao.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/entity/AuthorizationKakao.java
@@ -1,0 +1,13 @@
+package com.Techeer.Team_C.domain.auth.entity;
+
+import lombok.Data;
+
+@Data
+public class AuthorizationKakao {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/Techeer/Team_C/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/jwt/JwtTokenProvider.java
@@ -1,10 +1,11 @@
-
 package com.Techeer.Team_C.domain.auth.jwt;
 
 import com.Techeer.Team_C.domain.auth.dto.TokenDto;
 import com.Techeer.Team_C.domain.user.entity.Role;
 import io.jsonwebtoken.*;
+
 import javax.servlet.ServletRequest;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -31,14 +32,14 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")   //.yml파일을 통해 secret키 관리
     private String secretKey;
 
-
     private long tokenValidTime = 30 * 60 * 1000L; //토큰 유효시간 30분
     private long refreshTokenValidTime = 7 * 24 * 60 * 60 * 1000L; // refresh 유효시간 : 7일
 
     // 객체 초기화, secretKey를 Base64로 인코딩한다.
     @PostConstruct
     protected void init() {
-        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        secretKey = Base64.getEncoder()
+                .encodeToString(secretKey.getBytes());
     }
 
     // JWT 토큰 생성
@@ -51,7 +52,8 @@ public class JwtTokenProvider {
      */
     public TokenDto createToken(Authentication authentication) {
         // 권한들 가져오기
-        String authorities = authentication.getAuthorities().stream()
+        String authorities = authentication.getAuthorities()
+                .stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
@@ -80,8 +82,7 @@ public class JwtTokenProvider {
                 .build();
     }
 
-
-    public TokenDto createTokenSocialLogin(String email) {
+    public TokenDto createTokenSocialLogin(Long userId) {
 
         Role authority = Role.ROLE_USER;
         long now = (new Date()).getTime();
@@ -89,7 +90,7 @@ public class JwtTokenProvider {
         // Access Token 생성
         Date accessTokenExpiresIn = new Date(now + tokenValidTime);
         String accessToken = Jwts.builder()
-                .setSubject(email)       // payload "sub": "name"
+                .setSubject(String.valueOf(userId))       // payload "sub": "name"
                 .claim(AUTHORITIES_KEY, authority)        // payload "auth": "ROLE_USER"
                 .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
                 .signWith(SignatureAlgorithm.HS256, secretKey)   // header "alg": "HS512"
@@ -109,7 +110,6 @@ public class JwtTokenProvider {
                 .build();
     }
 
-
     public Authentication getAuthentication(String accessToken) {
         // 토큰 복호화
         Claims claims = parseClaims(accessToken);
@@ -119,10 +119,11 @@ public class JwtTokenProvider {
         }
 
         // 클레임에서 권한 정보 가져오기
-        Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                        .map(SimpleGrantedAuthority::new)
-                        .collect(Collectors.toList());
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get(AUTHORITIES_KEY)
+                        .toString()
+                        .split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
 
         // UserDetails 객체를 만들어서 Authentication 리턴
         UserDetails principal = new User(claims.getSubject(), "", authorities);
@@ -133,18 +134,24 @@ public class JwtTokenProvider {
     //토큰 복호화 함수
     private Claims parseClaims(String accessToken) {
         try {
-            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(accessToken).getBody();
+            return Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(accessToken)
+                    .getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
     }
 
-
     // 토큰의 유효성 + 만료일자 확인
     public boolean validateToken(ServletRequest request, String jwtToken) {
         try {
-            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
-            return !claims.getBody().getExpiration().before(new Date());
+            Jws<Claims> claims = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(jwtToken);
+            return !claims.getBody()
+                    .getExpiration()
+                    .before(new Date());
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
             request.setAttribute("exception", INVALID_JTW_TOKEN_SIGNATURE);
@@ -170,8 +177,12 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String jwtToken) {
         try {
-            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
-            return !claims.getBody().getExpiration().before(new Date());
+            Jws<Claims> claims = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(jwtToken);
+            return !claims.getBody()
+                    .getExpiration()
+                    .before(new Date());
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {

--- a/src/main/java/com/Techeer/Team_C/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/jwt/JwtTokenProvider.java
@@ -2,6 +2,7 @@
 package com.Techeer.Team_C.domain.auth.jwt;
 
 import com.Techeer.Team_C.domain.auth.dto.TokenDto;
+import com.Techeer.Team_C.domain.user.entity.Role;
 import io.jsonwebtoken.*;
 import javax.servlet.ServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +62,35 @@ public class JwtTokenProvider {
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())       // payload "sub": "name"
                 .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
+                .signWith(SignatureAlgorithm.HS256, secretKey)   // header "alg": "HS512"
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + refreshTokenValidTime))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+
+    public TokenDto createTokenSocialLogin(String email) {
+
+        Role authority = Role.ROLE_USER;
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + tokenValidTime);
+        String accessToken = Jwts.builder()
+                .setSubject(email)       // payload "sub": "name"
+                .claim(AUTHORITIES_KEY, authority)        // payload "auth": "ROLE_USER"
                 .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
                 .signWith(SignatureAlgorithm.HS256, secretKey)   // header "alg": "HS512"
                 .compact();

--- a/src/main/java/com/Techeer/Team_C/domain/auth/service/AuthService.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/service/AuthService.java
@@ -61,8 +61,10 @@ public class AuthService {
         TokenDto tokenDto = tokenProvider.createToken(authentication);
 
         // 4. RefreshToken 저장
-        RefreshToken refreshToken = RefreshToken.builder().key(authentication.getName())
-                .value(tokenDto.getRefreshToken()).build();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(authentication.getName())
+                .value(tokenDto.getRefreshToken())
+                .build();
 
         refreshTokenRepository.save(refreshToken);
 
@@ -124,7 +126,7 @@ public class AuthService {
     }
 
     public RefreshToken refreshTokenValidCheck(Authentication authentication,
-            TokenRefreshDto tokenRefreshDto) {
+                                               TokenRefreshDto tokenRefreshDto) {
         //  저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
         RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
                 .orElseThrow(
@@ -132,7 +134,8 @@ public class AuthService {
 
         // Refresh Token 일치하는지 검사
 
-        if (!refreshToken.getValue().equals(tokenRefreshDto.getRefreshToken())) {
+        if (!refreshToken.getValue()
+                .equals(tokenRefreshDto.getRefreshToken())) {
             throw new BusinessException("토큰과 유저정보가 서로 일치하지 않습니다.", MISMATCHED_USER_INFORMATION);
         }
         return refreshToken;
@@ -143,10 +146,12 @@ public class AuthService {
         User userInfoFromKakao = oauth2Kakao.getUserByAccessToken(authorization.getAccess_token());
 
         // JWT 토큰 생성
-        TokenDto tokenDto = tokenProvider.createTokenSocialLogin(userInfoFromKakao.getEmail());
+        TokenDto tokenDto = tokenProvider.createTokenSocialLogin(userInfoFromKakao.getUserId());
 
-        RefreshToken refreshToken = RefreshToken.builder().key(userInfoFromKakao.getEmail())
-                .value(tokenDto.getRefreshToken()).build();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(String.valueOf(userInfoFromKakao.getUserId()))
+                .value(tokenDto.getRefreshToken())
+                .build();
         refreshTokenRepository.save(refreshToken);
 
         return tokenDto;
@@ -156,10 +161,12 @@ public class AuthService {
         AuthorizationGoogle authorization = oauth2Google.getAccessTokenByCode(code);
         User userInfoFromGoogle = oauth2Google.getUserByAccessToken(authorization.getAccess_token());
 
-        TokenDto tokenDto = tokenProvider.createTokenSocialLogin(userInfoFromGoogle.getEmail());
+        TokenDto tokenDto = tokenProvider.createTokenSocialLogin(userInfoFromGoogle.getUserId());
 
-        RefreshToken refreshToken = RefreshToken.builder().key(userInfoFromGoogle.getEmail())
-                .value(tokenDto.getRefreshToken()).build();
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(String.valueOf(userInfoFromGoogle.getUserId()))
+                .value(tokenDto.getRefreshToken())
+                .build();
         refreshTokenRepository.save(refreshToken);
 
         return tokenDto;

--- a/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Google.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Google.java
@@ -83,16 +83,20 @@ public class Oauth2Google {
             String userInfo = response.getBody();
 
             JsonNode jsonNode = objectMapper.readTree(userInfo);
-            String email = String.valueOf(jsonNode.get("email"));
-            String name = String.valueOf(jsonNode.get("name"));
+            String rawEmail = String.valueOf(jsonNode.get("email"));
+            String rawName = String.valueOf(jsonNode.get("name"));
+
+            String email = rawEmail.substring(1, rawEmail.length() - 1);
+            String name = rawName.substring(1, rawName.length() - 1);
 
             userByEmail = userRepository.findByEmail(email);
             if (!userByEmail.isPresent()) {
-                User user = new User();
-                user.setEmail(email.substring(1, email.length() - 1));
-                user.setMemberName(name.substring(1, name.length() - 1));
-                user.setRole(Role.ROLE_USER);
-                user.setActivated(true);
+                User user = User.builder()
+                        .email(email)
+                        .memberName(name)
+                        .role(Role.ROLE_USER)
+                        .activated(true)
+                        .build();
 
                 return userRepository.save(user);
             }

--- a/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Google.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Google.java
@@ -1,6 +1,6 @@
 package com.Techeer.Team_C.domain.auth.service;
 
-import com.Techeer.Team_C.domain.auth.entity.AuthorizationKakao;
+import com.Techeer.Team_C.domain.auth.entity.AuthorizationGoogle;
 import com.Techeer.Team_C.domain.user.entity.Role;
 import com.Techeer.Team_C.domain.user.entity.User;
 import com.Techeer.Team_C.domain.user.repository.UserRepository;
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -24,47 +25,43 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Optional;
 
-import static com.Techeer.Team_C.global.error.exception.ErrorCode.*;
+import static com.Techeer.Team_C.global.error.exception.ErrorCode.ACCESS_TOKEN_NOT_FOUND;
+import static com.Techeer.Team_C.global.error.exception.ErrorCode.SOCIAL_LOGIN_USER_NOT_FOUND;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class Oauth2Kakao {
+public class Oauth2Google {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final UserRepository userRepository;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
-    private String grantType;
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String GOOGLE_SNS_CLIENT_ID;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
-    private String kakaoOauth2ClientId;
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String GOOGLE_SNS_CALLBACK_URL;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
-    private String redirectUrl;
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String GOOGLE_SNS_CLIENT_SECRET;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
-    private String clientSecret;
-
-    public AuthorizationKakao getAccessTokenByCode(String code) {
+    public AuthorizationGoogle getAccessTokenByCode(String code) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", grantType);
-        params.add("client_id", kakaoOauth2ClientId);
-        params.add("redirect_uri", redirectUrl);
         params.add("code", code);
-        params.add("client_secret", clientSecret);
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("redirect_uri", GOOGLE_SNS_CALLBACK_URL);
+        params.add("grant_type", "authorization_code");
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
-        String url = "https://kauth.kakao.com/oauth/token";
+        String url = "https://oauth2.googleapis.com/token";
         try {
             ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
-
-            AuthorizationKakao authorization = objectMapper.readValue(response.getBody(), AuthorizationKakao.class);
-
+            AuthorizationGoogle authorization = objectMapper.readValue(response.getBody(), AuthorizationGoogle.class);
             return authorization;
         } catch (RestClientException | JsonProcessingException ex) {
             ex.printStackTrace();
@@ -72,30 +69,22 @@ public class Oauth2Kakao {
         }
     }
 
-
-    /**
-     * accessToken 을 이용한 유저정보 받기
-     * @return
-     */
     public User getUserByAccessToken(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
 
-        String url = "https://kapi.kakao.com/v2/user/me";
+        String url = "https://www.googleapis.com/oauth2/v1/userinfo";
         Optional<User> userByEmail = null;
         try {
-            String userInfo = restTemplate.postForObject(url, request, String.class);
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
+            String userInfo = response.getBody();
 
             JsonNode jsonNode = objectMapper.readTree(userInfo);
-            String email = String.valueOf(jsonNode.get("kakao_account")
-                    .get("email"));
-            String name = String.valueOf(jsonNode.get("kakao_account")
-                    .get("profile")
-                    .get("nickname"));
+            String email = String.valueOf(jsonNode.get("email"));
+            String name = String.valueOf(jsonNode.get("name"));
 
             userByEmail = userRepository.findByEmail(email);
             if (!userByEmail.isPresent()) {

--- a/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Kakao.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Kakao.java
@@ -72,9 +72,9 @@ public class Oauth2Kakao {
         }
     }
 
-
     /**
      * accessToken 을 이용한 유저정보 받기
+     *
      * @return
      */
     public User getUserByAccessToken(String accessToken) {
@@ -91,19 +91,23 @@ public class Oauth2Kakao {
             String userInfo = restTemplate.postForObject(url, request, String.class);
 
             JsonNode jsonNode = objectMapper.readTree(userInfo);
-            String email = String.valueOf(jsonNode.get("kakao_account")
+            String rawEmail = String.valueOf(jsonNode.get("kakao_account")
                     .get("email"));
-            String name = String.valueOf(jsonNode.get("kakao_account")
+            String rawName = String.valueOf(jsonNode.get("kakao_account")
                     .get("profile")
                     .get("nickname"));
 
+            String email = rawEmail.substring(1, rawEmail.length() - 1);
+            String name = rawName.substring(1, rawName.length() - 1);
+
             userByEmail = userRepository.findByEmail(email);
             if (!userByEmail.isPresent()) {
-                User user = new User();
-                user.setEmail(email.substring(1, email.length() - 1));
-                user.setMemberName(name.substring(1, name.length() - 1));
-                user.setRole(Role.ROLE_USER);
-                user.setActivated(true);
+                User user = User.builder()
+                        .email(email)
+                        .memberName(name)
+                        .role(Role.ROLE_USER)
+                        .activated(true)
+                        .build();
 
                 return userRepository.save(user);
             }

--- a/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Kakao.java
+++ b/src/main/java/com/Techeer/Team_C/domain/auth/service/Oauth2Kakao.java
@@ -1,0 +1,122 @@
+package com.Techeer.Team_C.domain.auth.service;
+
+import com.Techeer.Team_C.domain.auth.entity.AuthorizationKakao;
+import com.Techeer.Team_C.domain.user.entity.Role;
+import com.Techeer.Team_C.domain.user.entity.User;
+import com.Techeer.Team_C.domain.user.repository.UserRepository;
+import com.Techeer.Team_C.global.error.exception.BusinessException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static com.Techeer.Team_C.global.error.exception.ErrorCode.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class Oauth2Kakao {
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
+    private String grantType;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoOauth2ClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUrl;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    public AuthorizationKakao getAccessTokenByCode(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", grantType);
+        params.add("client_id", kakaoOauth2ClientId);
+        params.add("redirect_uri", redirectUrl);
+        params.add("code", code);
+        params.add("client_secret", clientSecret);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        String url = "https://kauth.kakao.com/oauth/token";
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+
+            AuthorizationKakao authorization = objectMapper.readValue(response.getBody(), AuthorizationKakao.class);
+
+            return authorization;
+        } catch (RestClientException | JsonProcessingException ex) {
+            ex.printStackTrace();
+            throw new BusinessException("소셜로그인 접근 오류", ACCESS_TOKEN_NOT_FOUND);
+        }
+    }
+
+
+    /**
+     * accessToken 을 이용한 유저정보 받기
+     * @return
+     */
+    public User getUserByAccessToken(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        String url = "https://kapi.kakao.com/v2/user/me";
+        Optional<User> userByEmail = null;
+        try {
+            String userInfo = restTemplate.postForObject(url, request, String.class);
+            System.out.println(userInfo);
+
+            JsonNode jsonNode = objectMapper.readTree(userInfo);
+            String email = String.valueOf(jsonNode.get("kakao_account")
+                    .get("email"));
+            String name = String.valueOf(jsonNode.get("kakao_account")
+                    .get("profile")
+                    .get("nickname"));
+
+            userByEmail = userRepository.findByEmail(email);
+            if (!userByEmail.isPresent()) {
+                User user = new User();
+                user.setEmail(email.substring(1, email.length() - 1));
+                user.setMemberName(name.substring(1, name.length() - 1));
+                user.setRole(Role.ROLE_USER);
+                user.setActivated(true);
+
+                return userRepository.save(user);
+            }
+            return userByEmail.get();
+        } catch (RestClientException ex) {
+            ex.printStackTrace();
+            throw new BusinessException("Social login user not found", SOCIAL_LOGIN_USER_NOT_FOUND);
+        } catch (JsonMappingException e) {
+            e.printStackTrace();
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return userByEmail.get();
+    }
+}

--- a/src/main/java/com/Techeer/Team_C/domain/user/entity/User.java
+++ b/src/main/java/com/Techeer/Team_C/domain/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.Techeer.Team_C.domain.user.entity;
 
 import com.Techeer.Team_C.domain.product.entity.ProductRegister;
-//import com.Techeer.Team_C.domain.product.entity.ProductRegisterId;
 import com.Techeer.Team_C.global.utils.dto.BaseTimeEntity;
 import com.Techeer.Team_C.global.utils.dto.BooleanToYNConverter;
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import lombok.Setter;
-
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.lang.Nullable;

--- a/src/main/java/com/Techeer/Team_C/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/Techeer/Team_C/domain/user/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository {
     Optional<User> findById(Long Userid);  //회원의 email 값으로 정보 찾기
 
     Optional<User> findByEmail(String email);
+
 }

--- a/src/main/java/com/Techeer/Team_C/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/Techeer/Team_C/global/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.Techeer.Team_C.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/Techeer/Team_C/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/Techeer/Team_C/global/error/exception/ErrorCode.java
@@ -21,6 +21,10 @@ public enum ErrorCode {
     NO_PERMISSION(403, "M005", "Do not have permission."),
     USER_NOT_FOUND(401,"M006","Not found this User"),
 
+    //Social Login
+    ACCESS_TOKEN_NOT_FOUND(400, "E00001", "Cannot access to SocialLogin"),
+    SOCIAL_LOGIN_USER_NOT_FOUND(401, "E00002", "Cannot find user from Social"),
+
     //jwtToken
     INVALID_JTW_TOKEN_SIGNATURE(401, "J001", "The token's signature is invalid."),
     EXPIRED_JTW_TOKEN(401, "J002", "Token data has expired"),


### PR DESCRIPTION
## 변경사항

구글, 카카오 소셜로그인 방식
Spring Security 사용하는 방식에서 Oauth2 사용해서 직접 구글, 카카오 측으로 Rest API 요청 보내는 방식으로 변경
-> 기존에 WebSecurityConfig 에서 충돌나던 오류 해결


### `GET /api/v1/auth/token/kakao`
- 카카오에서 받아온 인가코드를 넘겨주면 해당 인가코드를 이용해 카카오측으로부터 access token을 받아오고, 해당 access token을 이용해 사용자 정보를 받아옵니다.
- 받아온 유저가 DB에 없는 경우 새로 등록하고, 저희 서버의 jwt access token과 refresh token을 반환합니다.


### `GET /api/v1/auth/token/google`
- 구글측에서 받아온 인가코드를 넘겨주면 해당 인가코드를 이용해 구글측에서부터 access token을 받아오고 해당 토큰을 이용해 사용자 정보를 받아옵니다.
- 이후 로직은 카카오와 동일하며, jwt access token과 refresh token을 반환합니다.


혹시 테스트 해보실 분들은 인가코드 받는 방법 저 또는 @jungmaan 님께 여쭤봐주시면 됩니다!

<br>

## TODO
- 프론트 배포 후 구글과 카카오에서 리다이렉트 주소 변경
- 카카오 로그아웃 후 리다이렉트 페이지 주소 추가
- 기존의 Spring Security 사용 시 쓰던 불필요한 코드들 삭제 (혹시 충돌날까봐 지금은 그대로 뒀습니다. 추후 리팩토링 시 삭제 예정입니다.)