### PR TITLE
Feature/hide password

### DIFF
--- a/src/main/java/com/Techeer/Team_C/domain/user/dto/UserResponeDto.java
+++ b/src/main/java/com/Techeer/Team_C/domain/user/dto/UserResponeDto.java
@@ -1,0 +1,29 @@
+package com.Techeer.Team_C.domain.user.dto;
+
+import com.Techeer.Team_C.domain.user.entity.Role;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class UserResponeDto {
+
+    @ApiModelProperty(example = "회원 식별 Id")
+    private Long userId;
+
+    @ApiModelProperty(example = "회원 아이디(이메일)")
+    private String email;
+
+    @ApiModelProperty(example = "회원 닉네임")
+    private String memberName;
+
+    @ApiModelProperty(example = "회원의 권한 (USER / ADMIN)")
+    private Role role;
+
+}

--- a/src/main/java/com/Techeer/Team_C/domain/user/service/UserService.java
+++ b/src/main/java/com/Techeer/Team_C/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.Techeer.Team_C.domain.user.service;
 
 import com.Techeer.Team_C.domain.user.dto.PasswordChangeRequestDto;
 import com.Techeer.Team_C.domain.user.dto.UserDto;
+import com.Techeer.Team_C.domain.user.dto.UserResponeDto;
 import com.Techeer.Team_C.domain.user.entity.User;
 import com.Techeer.Team_C.domain.user.repository.UserRepository;
 
@@ -33,6 +34,11 @@ public class UserService {
 
     private UserDto dtoConverter(User user) {
         return modelMapper.map(user, UserDto.class);
+        // Serice에서는 user entitiy에 바로 접근하지 않고, User entitiy를 user Dto로 변경하여 dto에 접근
+    }
+
+    private UserResponeDto ResponeDtoConverter(User user) {
+        return modelMapper.map(user, UserResponeDto.class);
         // Serice에서는 user entitiy에 바로 접근하지 않고, User entitiy를 user Dto로 변경하여 dto에 접근
     }
 
@@ -82,7 +88,7 @@ public class UserService {
      * @return 해당 user객체의 데이터
      */
     @Transactional
-    public Optional<UserDto> getMyinfo() {
+    public Optional<UserResponeDto> getMyinfo() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getName() == null) {
             throw new BusinessException("Security Context 에 인증 정보가 없습니다", EMPTY_TOKEN_DATA);
@@ -90,7 +96,7 @@ public class UserService {
 
         Long id = Long.parseLong(authentication.getName());
         Optional<User> userById = userRepository.findById(id);
-        return userById.map(userEntity -> dtoConverter(userEntity));
+        return userById.map(userEntity -> ResponeDtoConverter(userEntity));
 
     }
 


### PR DESCRIPTION
## 회원 조회시 비밀번호까지 반환하는 이슈 해결

유저 아이디, 이메일, 회원 닉네임, 권한 4가지 요소만을 가진 UserResponeDTo 를 생성했습니다.

회원 비밀번호를 같이 반환하던 GetMyInfo 메서드의 반환 형식을 새로운 Dto에 맵핑하여 반환합니다!

---

findMember 메서드에서도 기존의 비밀번호가 있는 Dto 형식으로 반환하는데 해당 부분은 비밀번호가 필요한 메서드라서 수정하지 않고 놔두었습니다!